### PR TITLE
Added functionality to ensure that labels aren't added more than once

### DIFF
--- a/gitissuebot/main.py
+++ b/gitissuebot/main.py
@@ -232,14 +232,11 @@ def update_inactive_issues(issues, query_func=run_query):
     labelids = config['labelids']
 
     for issue in issues:
-        print(issue)
         age = find_most_recent_activity(issue)
         try:
             lnames = [x['node']['name'] for x in issue['labels']['edges']]
-        except KeyError as e:
-            print(e)
+        except KeyError:
             lnames = []
-        print(lnames)
         if age.days >= 365:
             resp = update_with_message(issue['id'], config['final_message'], query_func=query_func)
             resp = add_label(issue['id'], labelids['automatically_closed'], query_func=query_func)

--- a/gitissuebot/main.py
+++ b/gitissuebot/main.py
@@ -234,16 +234,16 @@ def update_inactive_issues(issues, query_func=run_query):
     for issue in issues:
         age = find_most_recent_activity(issue)
         try:
-            lnames = [x['node']['name'] for x in issue['labels']['edges']]
+            issue_labels = [x['node']['name'] for x in issue['labels']['edges']]
         except KeyError:
-            lnames = []
+            issue_labels = []
         if age.days >= 365:
             resp = update_with_message(issue['id'], config['final_message'], query_func=query_func)
             resp = add_label(issue['id'], labelids['automatically_closed'], query_func=query_func)
             resp = close_issue(issue['id'], query_func=query_func)
-        elif age.days >= 335 and 'pending_closure' not in lnames:
+        elif age.days >= 335 and 'pending_closure' not in issue_labels:
             resp = update_with_message(issue['id'], config['second_message'], query_func=query_func)
             resp = add_label(issue['id'], labelids['pending_closure'], query_func=query_func)
-        elif age.days >= 182 and age.days <= 334 and 'inactive' not in lnames:
+        elif age.days >= 182 and age.days <= 334 and 'inactive' not in issue_labels:
             resp = update_with_message(issue['id'], config['first_message'], query_func=query_func)
             resp = add_label(issue['id'], labelids['inactive'], query_func=query_func)

--- a/gitissuebot/main.py
+++ b/gitissuebot/main.py
@@ -241,9 +241,9 @@ def update_inactive_issues(issues, query_func=run_query):
             resp = update_with_message(issue['id'], config['final_message'], query_func=query_func)
             resp = add_label(issue['id'], labelids['automatically_closed'], query_func=query_func)
             resp = close_issue(issue['id'], query_func=query_func)
-        elif age.days >= 335 and 'pending_close' not in lnames:
+        elif age.days >= 335 and 'pending_closure' not in lnames:
             resp = update_with_message(issue['id'], config['second_message'], query_func=query_func)
-            resp = add_label(issue['id'], labelids['pending_close'], query_func=query_func)
+            resp = add_label(issue['id'], labelids['pending_closure'], query_func=query_func)
         elif age.days >= 182 and age.days <= 334 and 'inactive' not in lnames:
             resp = update_with_message(issue['id'], config['first_message'], query_func=query_func)
             resp = add_label(issue['id'], labelids['inactive'], query_func=query_func)

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -2,11 +2,13 @@ git_url: "mock://test.org"
 owner: "NoOneKnows"
 repository: "TestTime"
 APIKEY: "my_magic_secret"
+ssl_cert: "False"
 
 labelids:
   inactive: "MDU6TGFiZWwyMjg1Mjc0MTc2"
   automatically_closed: "MDU6TGFiZWwyMjg1Mjc2MjI3"
-        
+  pending_close: "MDU6TGFiZWwyMzU5MDg1NjAy"
+
 first_message: |
   I am a bot that cleans up old issues that do not have activity.
 

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -7,7 +7,7 @@ ssl_cert: "False"
 labelids:
   inactive: "MDU6TGFiZWwyMjg1Mjc0MTc2"
   automatically_closed: "MDU6TGFiZWwyMjg1Mjc2MjI3"
-  pending_close: "MDU6TGFiZWwyMzU5MDg1NjAy"
+  pending_closure: "MDU6TGFiZWwyMzU5MDg1NjAy"
 
 first_message: |
   I am a bot that cleans up old issues that do not have activity.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -107,12 +107,52 @@ def test_inactive_182():
         assert update.called
         assert label.called
 
+
+def test_already_inactive_182():
+    with mock.patch('gitissuebot.main.find_most_recent_activity', return_value=timedelta(182)) as fmr,\
+        mock.patch('gitissuebot.main.update_with_message') as update,\
+        mock.patch('gitissuebot.main.add_label') as label:
+        update_inactive_issues([{'id':"foo",
+                                 'labels':
+                                    {'edges':
+                                        [{'node':
+                                            {'id': 'MDU6TGFiZWwyMzA4MTcyMjM5',
+                                            'name': 'inactive'}
+                                            }
+                                        ]}
+                                    }
+                                ])
+        assert fmr.called
+        assert not update.called
+        assert not label.called
+
+
+def test_already_inactive_335():
+    with mock.patch('gitissuebot.main.find_most_recent_activity', return_value=timedelta(335)) as fmr,\
+        mock.patch('gitissuebot.main.update_with_message') as update,\
+        mock.patch('gitissuebot.main.add_label') as label:
+        update_inactive_issues([{'id':"foo",
+                                 'labels':
+                                    {'edges':
+                                        [{'node':
+                                            {'id': 'MDU6TGFiZWwyMzU5MDg1NjAy',
+                                            'name': 'pending_close'}
+                                            }
+                                        ]}
+                                    }
+                                ])
+        assert fmr.called
+        assert not update.called
+        assert not label.called
+
 def test_inactive_335():
     with mock.patch('gitissuebot.main.find_most_recent_activity', return_value=timedelta(335)) as fmr,\
-        mock.patch('gitissuebot.main.update_with_message') as update:
+        mock.patch('gitissuebot.main.update_with_message') as update,\
+        mock.patch('gitissuebot.main.add_label') as label:
         update_inactive_issues([{'id':"foo"},])
         assert fmr.called
         assert update.called
+        assert label.called
 
     with mock.patch('gitissuebot.main.find_most_recent_activity', return_value=timedelta(366)) as fmr,\
         mock.patch('gitissuebot.main.update_with_message') as update,\

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -108,6 +108,26 @@ def test_inactive_182():
         assert label.called
 
 
+def test_inactive_335():
+    with mock.patch('gitissuebot.main.find_most_recent_activity', return_value=timedelta(335)) as fmr,\
+        mock.patch('gitissuebot.main.update_with_message') as update,\
+        mock.patch('gitissuebot.main.add_label') as label:
+        update_inactive_issues([{'id':"foo"},])
+        assert fmr.called
+        assert update.called
+        assert label.called
+
+    with mock.patch('gitissuebot.main.find_most_recent_activity', return_value=timedelta(366)) as fmr,\
+        mock.patch('gitissuebot.main.update_with_message') as update,\
+        mock.patch('gitissuebot.main.add_label') as label,\
+        mock.patch('gitissuebot.main.close_issue') as close:
+        update_inactive_issues([{'id':"foo"},])
+        assert fmr.called
+        assert update.called
+        assert label.called
+        assert close.called
+
+
 def test_already_inactive_182():
     with mock.patch('gitissuebot.main.find_most_recent_activity', return_value=timedelta(182)) as fmr,\
         mock.patch('gitissuebot.main.update_with_message') as update,\
@@ -144,22 +164,3 @@ def test_already_inactive_335():
         assert fmr.called
         assert not update.called
         assert not label.called
-
-def test_inactive_335():
-    with mock.patch('gitissuebot.main.find_most_recent_activity', return_value=timedelta(335)) as fmr,\
-        mock.patch('gitissuebot.main.update_with_message') as update,\
-        mock.patch('gitissuebot.main.add_label') as label:
-        update_inactive_issues([{'id':"foo"},])
-        assert fmr.called
-        assert update.called
-        assert label.called
-
-    with mock.patch('gitissuebot.main.find_most_recent_activity', return_value=timedelta(366)) as fmr,\
-        mock.patch('gitissuebot.main.update_with_message') as update,\
-        mock.patch('gitissuebot.main.add_label') as label,\
-        mock.patch('gitissuebot.main.close_issue') as close:
-        update_inactive_issues([{'id':"foo"},])
-        assert fmr.called
-        assert update.called
-        assert label.called
-        assert close.called

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -136,7 +136,7 @@ def test_already_inactive_335():
                                     {'edges':
                                         [{'node':
                                             {'id': 'MDU6TGFiZWwyMzU5MDg1NjAy',
-                                            'name': 'pending_close'}
+                                            'name': 'pending_closure'}
                                             }
                                         ]}
                                     }


### PR DESCRIPTION
Added a check to see if the label is already on the issue.  If an "inactive" or "pending_close" label is attached to the issue, then those labels won't be added.